### PR TITLE
Documentation dependency issue

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,6 +11,6 @@ You must be using Unity > 2019.1!
 * In your unity project root open `Packages/manifest.json`
 * Add the following line to the dependencies section 
 ```
-    "com.redowl.editor.uiex": "https://github.com/red-owl-games/UIEX.git",
+    "com.redowl.uiex": "https://github.com/red-owl-games/UIEX.git",
 ```
 * Open Unity and the package should download automatically and you are ready to go!


### PR DESCRIPTION
In the documentation:
https://redowlgames.com/UIEX/installation.html

it states that you should use ` "com.redowl.editor.uiex": "https://github.com/red-owl-games/UIEX.git"` but the package isn't using this name anymore, which gives this issue:

```An error occurred while resolving packages:
  Project has invalid dependencies:
    com.redowl.editor.uiex: The requested dependency 'com.redowl.editor.uiex' does not match the `name` 'com.redowl.uiex' specified in the package manifest of [com.redowl.editor.uiex@https://github.com/red-owl-games/UIEX.git]

A re-import of the project may be required to fix the issue or a manual modification of .../Packages/manifest.json file.
```


